### PR TITLE
ヘッダーとフッダーのレスポンシブ対応

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import{
 	Switch,
 	Route,
 } from "react-router-dom";
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {Top} from './containers/Top.jsx';
 import {SignIn} from './containers/SignIn.jsx';
 import {LogIn} from './containers/LogIn.jsx';
@@ -12,6 +12,7 @@ import {RequestForm} from './containers/RequestForm.jsx';
 import {MyPage} from './containers/MyPage.jsx';
 import {Header} from './containers/Header.jsx';
 import {LoginHeader} from './containers/LoginHeader.jsx';
+import {LoginHeaderSP} from './containers/LoginHeaderSP.jsx';
 import {Footer} from './containers/Footer.jsx';
 import {NotReady} from './containers/NotReady.jsx';
 import {Chats} from './containers/Chats.jsx';
@@ -34,11 +35,29 @@ function App() {
 	}));
 
 	const cookies = useCookies(['accessToken'])[0];
+	const [dimension, setDimension] = useState({width: window.innerWidth})
+
+	useEffect(() => {
+		setDimension({width: window.innerWidth})
+	},[])
 
   	return (
 	  	<Router>
 			{
-				cookies.accessToken && 
+				console.log(cookies.accessToken)
+			}
+			{
+				console.log(dimension.width)
+			}
+			{
+				console.log(dimension.width <= 480)
+			}
+			{
+				cookies.accessToken && (dimension.width <= 480) &&
+				<LoginHeaderSP/>
+			}
+			{
+				cookies.accessToken && (dimension.width > 480) &&
 				<LoginHeader/>
 			}
 			{

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import {Header} from './containers/Header.jsx';
 import {LoginHeader} from './containers/LoginHeader.jsx';
 import {LoginHeaderSP} from './containers/LoginHeaderSP.jsx';
 import {Footer} from './containers/Footer.jsx';
+import {LoginFooterSP} from './containers/LoginFooterSP.jsx';
 import {NotReady} from './containers/NotReady.jsx';
 import {Chats} from './containers/Chats.jsx';
 import {Chat} from './containers/Chat.jsx';
@@ -30,7 +31,7 @@ function App() {
 	});
 	
 	const BaseComponent = styled('div')(({theme}) => ({
-		minHeight:'100vh',
+		minHeight:'80vh',
 		backgroundColor: theme.palette.primary.main,
 	}));
 
@@ -101,7 +102,14 @@ function App() {
 	  					</Switch>
 					</BaseComponent>
 				</ThemeProvider>
-			<Footer/>
+			{
+				cookies.accessToken && (dimension.width <= 480) &&
+				<LoginFooterSP/>
+			}
+			{
+				!(cookies.accessToken && (dimension.width <= 480)) &&
+				<Footer/>
+			}
 	  	</Router>
   );
 }

--- a/src/containers/Chat.jsx
+++ b/src/containers/Chat.jsx
@@ -121,6 +121,7 @@ export const Chat = (props) => {
     });
 	
 	useEffect(() => {
+		window.scroll({top: document.body.scrollHeight, behavior: 'smooth'});
 		const sub = cable.subscriptions.create({ channel: 'ChatChannel', room_id: roomId}, {
 			received: (msg) => {
 				setReceivedMessage(msg) 

--- a/src/containers/Chats.jsx
+++ b/src/containers/Chats.jsx
@@ -137,6 +137,7 @@ export const Chats = () => {
 
 
 	useLayoutEffect(() => {
+		window.scrollTo({ top: 0, behavior: "smooth"})
 		getChats(cookies.accessToken)
 		.then((data) => {
 			setChatsInfo(data)

--- a/src/containers/Footer.jsx
+++ b/src/containers/Footer.jsx
@@ -16,7 +16,7 @@ const Theme = createTheme({
 });
 
 const FooterWrapper = styled('div')(({ theme }) => ({
-	height: 150,
+	height: 100,
 	display: 'flex',
 	justifyContent: 'flex-end',
 	alignItems: 'center',

--- a/src/containers/LogIn.jsx
+++ b/src/containers/LogIn.jsx
@@ -31,6 +31,9 @@ export const LogIn = () => {
 	const MessageWrapper = styled('div')({
 		width: '100%',
 		height: 90,
+		"@media screen and (max-width:480px)":{
+			height: 50,
+		},
 	});
 
 	const LogInTitle = styled('div')({

--- a/src/containers/LoginFooterSP.jsx
+++ b/src/containers/LoginFooterSP.jsx
@@ -1,0 +1,68 @@
+import {styled, ThemeProvider, createTheme} from '@mui/material/styles';
+import Button from '@mui/material/Button';
+import{
+	useHistory,
+} from "react-router-dom";
+
+const Theme = createTheme({
+	palette: {
+		background: {
+			primary: '#F5F5F5',
+		},
+		text: {
+			primary: '#263238',
+		},
+		main: {
+			primary: '#ffa500',
+			secondary: '#ffd700',
+		},
+	},
+});
+
+const FooterWrapper = styled('div')(({ theme }) => ({
+	height: 60,
+	position: 'sticky',
+	bottom: 0,
+	zIndex: 10,
+	width: '100%',
+	display: 'flex',
+	justifyContent: 'center',
+	alignItems: 'center',
+	backgroundColor: theme.palette.background.primary,
+}));
+
+const FooterButton = styled(Button)(({ theme, props }) => ({
+	width: 100,
+	fontSize: 10,
+	color: theme.palette.text.primary,
+	fontFamily: 'HiraKakuProN-W6',
+	borderRadius: 50,
+}));
+
+export const LoginFooterSP = () => {
+	const history = useHistory();
+	return(
+		<ThemeProvider theme={Theme} >
+			<FooterWrapper>	
+					<FooterButton
+						sx={{ mr: 1, bgcolor: 'main.primary'}}
+						variant='outlined'
+						color='inherit'
+						onClick={()=>{
+							history.push("/mypage", {loginNotice: false});
+						}}
+					>マイページ</FooterButton>
+					<FooterButton
+						sx={{ ml: 1,bgcolor: 'main.secondary'}}
+						variant='outlined'
+						color='inherit'
+						onClick={()=>{
+							history.push("/chats");
+						}}
+					>チャット一覧</FooterButton>
+			</FooterWrapper>
+		</ThemeProvider>
+	);
+};
+
+

--- a/src/containers/LoginHeaderSP.jsx
+++ b/src/containers/LoginHeaderSP.jsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import AppBar from '@mui/material/AppBar';
+import Box from '@mui/material/Box';
+import Toolbar from '@mui/material/Toolbar';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import SportsBarIcon from '@mui/icons-material/SportsBarOutlined';
+import Container from '@mui/material/Container';
+import {styled, ThemeProvider, createTheme} from '@mui/material/styles';
+import{
+	useHistory,
+} from "react-router-dom";
+import { LogOut } from '../apis/LogOut';
+import { useCookies } from 'react-cookie';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+
+export const LoginHeaderSP = () => {
+
+	const Theme = createTheme({
+		palette: {
+			background: {
+				primary: '#F5F5F5',
+			},
+			text: {
+				primary: '#263238',
+			},
+			main: {
+				primary: '#ffa500',
+				secondary: '#ffd700',
+			},
+		},
+	});
+
+	const history = useHistory();
+	const cookiesArray = useCookies(["accessToken"]);
+	const cookies = cookiesArray[0]
+	const removeCookie = cookiesArray[2]
+
+	const NomimatchAppBar = styled(AppBar)(({ theme }) => ({
+		backgroundColor: theme.palette.background.primary,
+	}));
+
+	const HeaderButton = styled(Button)(({ theme, props }) => ({
+		width: 100,
+		fontSize: 10,
+		color: theme.palette.text.primary,
+		fontFamily: 'HiraKakuProN-W6',
+		borderRadius: 50,
+	}));
+
+	const logout = () => {
+		if(window.confirm('ログアウトしますか？')){
+		LogOut(cookies["accessToken"])
+		.then(() => {
+			removeCookie('accessToken')
+			history.push("/",{logoutNotice: true})
+		}).catch(
+		)}
+	};
+
+
+  	return (
+	  	<ThemeProvider theme={Theme}>
+    		<Box sx={{ flexGrow: 1 }}>
+      			<NomimatchAppBar position="static">
+	  				<Container maxWidth="lg">
+        				<Toolbar>
+							<IconButton
+            				size="large"
+            				edge="start"
+            				color="inherit"
+            				aria-label="menu"
+            				sx={{ mr: 2 }}
+							onClick={()=>{
+								history.push("/", {logoutNotice: false});
+							}}
+          					>
+	  							<SportsBarIcon 
+								sx={{fontSize: 40, color: 'main.primary'}}/>
+          					</IconButton>
+	  						<div style={{flexGrow: 1}}></div>
+          					<HeaderButton
+							variant='outlined'
+							color='inherit'
+							onClick={logout}
+							>ログアウト</HeaderButton>
+							<IconButton
+            				size="large"
+            				edge="start"
+            				color="inherit"
+            				aria-label="menu"
+							onClick={()=>{
+								history.push("/notready");
+							}}
+          					>
+	  							<SettingsOutlinedIcon 
+								sx={{fontSize: 30, pl: 1, color: 'black'}}/>
+          					</IconButton>
+        				</Toolbar>
+	  				</Container>
+      			</NomimatchAppBar>
+    		</Box>
+	  	</ThemeProvider>
+  );
+}

--- a/src/containers/MyPage.jsx
+++ b/src/containers/MyPage.jsx
@@ -41,12 +41,15 @@ export const MyPage = () => {
 	const MessageWrapper = styled('div')({
 		width: '100%',
 		height: 90,
+		"@media screen and (max-width:480px)":{
+			height: 50,
+		},
 	});
 
 	const MyPageTitle = styled('div')({
 		fontSize: 30,
 		"@media screen and (max-width:480px)":{
-			fontSize: 27,
+			fontSize: 22,
 		},
 		fontFamily: 'HiraKakuProN-W6',
 		textAlign: 'center',

--- a/src/containers/RegisterRecommendDialog.jsx
+++ b/src/containers/RegisterRecommendDialog.jsx
@@ -1,0 +1,180 @@
+import React, { Fragment } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Button from '@mui/material/Button';
+import {styled, ThemeProvider, createTheme} from '@mui/material/styles';
+import Cheers from '../images/Beer Celebration-rafiki.png';
+import { TIME, NUMBER_OF_PEOPLE, BUDGET } from '../constants'
+import { setAtmosphere } from '../functions/setAtmosphere';
+import{
+	useHistory,
+} from "react-router-dom";
+
+
+export const RegisterRecommendDialog = ({
+	receiverName,
+	open,
+	onClose,
+}) => {
+
+	const Theme = createTheme({
+		palette: {
+			text: {
+				primary: '#263238',
+			},
+			main: {
+				primary: '#ffa500'
+			},	
+		},
+	});
+
+	const DialogWrapper = styled('div')({
+		fontSize: 20,
+		fontFamily: 'HiraKakuProN-W6',
+		textAlign: 'center',
+		paddingBottom: 20,
+		"@media screen and (max-width:480px)":{
+			fontSize: 12,
+		},
+	});
+	
+	const ContentWrapper = styled('div')({
+		paddingRight: 15,
+		paddingLeft: 15,
+		border: 'solid 1px #333',
+		borderRadius: 10,
+	});
+
+	const ReceiverName = styled('span')(({ theme }) => ({
+		color: theme.palette.main.primary,
+	}));
+
+	const RequestWrapper = styled('div')({
+		paddingTop: 30,
+		paddingBottom: 20,
+	});
+
+	const RequestItemName = styled('span')({
+		fontWeight: 'bold',
+	});
+
+	const  ActionsWrapper = styled('div')({
+		margin: '0 auto',
+	});
+
+	const EmphasizedButton = styled(Button)(({ theme }) => ({
+		width: 200,
+		fontSize: 15,
+		color: theme.palette.text.primary,
+		fontFamily: 'HiraKakuProN-W6',
+		borderRadius: 50,
+		marginBottom: 20,
+		"@media screen and (max-width:480px)":{
+			fontSize: 10,
+		},
+	}));
+
+	const NormalButton = styled(Button)(({ theme }) => ({
+		width: 330,
+		fontSize: 15,
+		color: theme.palette.text.primary,
+		fontFamily: 'HiraKakuProN-W6',
+		borderRadius: 50,
+		marginBottom: 20,
+		"@media screen and (max-width:480px)":{
+			width: 350,
+			fontSize: 8,
+		},
+	}));
+
+	const ImageWrapper = styled('div')({
+		textAlign: 'center',
+	});
+
+	const RequestFinishImage = styled('img')({
+		width: '70%',
+	});
+	
+	const ButtonWrapperTop = styled('div')({
+		display: 'flex',
+		justifyContent: 'center',
+		paddingTop: 20,
+	});
+
+	const WrapperMedium = styled('div')({
+		display: 'flex',
+		justifyContent: 'center',
+		marginBottom: 20,
+		fontSize: 20,
+		"@media screen and (max-width:480px)":{
+			fontSize: 15,
+		},
+	});
+
+	const ButtonWrapperButtom = styled('div')({
+		display: 'flex',
+		justifyContent: 'center',
+	});
+
+	const ButtonWrapper = styled('div')({
+		textAlign: 'center',
+		marginTop: 30,
+	});
+
+	const history = useHistory();
+
+	return (
+		<ThemeProvider theme={Theme}>
+		<Dialog
+		open = {open}
+		receiverName = {receiverName}
+		onClose = {onClose}		
+		>
+		<DialogContent>
+			<DialogWrapper>
+			ログインした後に依頼を送信すると<br/>
+			後で<ReceiverName>やまーだ</ReceiverName>さんとチャットすることができます！
+			</DialogWrapper>
+			<ButtonWrapperTop>
+			<EmphasizedButton
+			sx={{ mr: 1, bgcolor: 'main.primary' }}
+			variant='outlined'
+			color='inherit'
+			onClick={()=>{
+				history.push("/", {logoutNotice: false});
+			}}
+			>
+			新規登録
+			</EmphasizedButton>
+			<EmphasizedButton
+			sx={{ ml: 1, bgcolor: 'main.primary' }}
+			variant='outlined'
+			color='inherit'
+			onClick={()=>{
+				history.push("/", {logoutNotice: false});
+			}}
+			>
+			ログイン
+			</EmphasizedButton>
+			</ButtonWrapperTop>
+			<WrapperMedium>
+			or
+			</WrapperMedium>
+			<ButtonWrapperButtom>
+			<NormalButton
+			variant='outlined'
+			color='inherit'
+			onClick={()=>{
+				history.push("/", {logoutNotice: false});
+			}}
+			>
+			チャット機能なしで飲み会依頼を送る！
+			</NormalButton>
+			</ButtonWrapperButtom>
+		</DialogContent>
+		</Dialog>
+		</ThemeProvider>
+	)
+}

--- a/src/containers/RequestForm.jsx
+++ b/src/containers/RequestForm.jsx
@@ -21,7 +21,9 @@ import InputLabel from '@mui/material/InputLabel';
 import FormControl from '@mui/material/FormControl';
 import Slider from '@mui/material/Slider';
 import { RequestDialog } from './RequestDialog';
+import { RegisterRecommendDialog } from './RegisterRecommendDialog';
 import {usePageTracking} from '../functions/useTracking';
+import { useCookies } from 'react-cookie';
 
 export const RequestForm = ({
 	match
@@ -128,6 +130,7 @@ export const RequestForm = ({
 	const initialState = {
 		isSent: false,
 		isOpenDialog: false,
+		isOpenRecommendDialog: true,
 		condition: false,
 		errorMessages: [],
 	};
@@ -196,6 +199,8 @@ export const RequestForm = ({
 		})
 	};
 
+	const cookies  = useCookies(['accessToken'])[0];
+
 	useEffect(()=> {
 		window.scrollTo({ top: 0, behavior: "smooth"})
 	}, [errors])
@@ -204,6 +209,17 @@ export const RequestForm = ({
 		<Fragment>
 			<ThemeProvider theme={Theme}>
 			<Container maxWidth='lg'>
+				{
+					!cookies.accessToken &&
+					<RegisterRecommendDialog
+					receiverName = {request.receiverName}
+					open={state.isOpenRecommendDialog}
+					onClose={() => setState({
+						...state,
+						isOpenRecommendDialog: false,
+					})}
+					/>
+				}
 				{
 					state.errorMessages.map((message, index)=>{
 						window.scrollTo({ top: 0, behavior: "smooth"})

--- a/src/containers/SignIn.jsx
+++ b/src/containers/SignIn.jsx
@@ -33,6 +33,9 @@ export const SignIn = () => {
 	const MessageWrapper = styled('div')({
 		width: '100%',
 		height: 90,
+		"@media screen and (max-width:480px)":{
+			height: 50,
+		},
 	});
 
 	const SignInTitle = styled('div')({


### PR DESCRIPTION
## 概要
ヘッダーとフッダーのコンポーネントをスマホ画面とPC画面で使い分けるようにした。

## なぜこの機能を追加するのか
画面サイズに応じてレイアウトを変えたかったから。

## やったこと
- LoginHeaderSPコンポーネントを作成
- LoginFooterSPコンポーネントを作成
- App.jsを編集し、画面サイズに応じて描画するコンポーネントを変えるようにした。