### PR TITLE
未ログインユーザーが飲み会依頼送信ページに遷移したときにモーダルを表示する。

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -48,12 +48,6 @@ function App() {
 				console.log(cookies.accessToken)
 			}
 			{
-				console.log(dimension.width)
-			}
-			{
-				console.log(dimension.width <= 480)
-			}
-			{
 				cookies.accessToken && (dimension.width <= 480) &&
 				<LoginHeaderSP/>
 			}

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import{
 	Switch,
 	Route,
 } from "react-router-dom";
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import {Top} from './containers/Top.jsx';
 import {SignIn} from './containers/SignIn.jsx';
 import {LogIn} from './containers/LogIn.jsx';
@@ -20,6 +20,8 @@ import {Chats} from './containers/Chats.jsx';
 import {Chat} from './containers/Chat.jsx';
 import {styled, ThemeProvider, createTheme} from '@mui/system';
 import {useCookies} from 'react-cookie';
+import { UserInfoContext } from './providers/UserInfoProvider';
+import { getCurrentUser } from './apis/GetCurrentUserInfo';
 
 function App() {
 	const Theme = createTheme({
@@ -44,9 +46,6 @@ function App() {
 
   	return (
 	  	<Router>
-			{
-				console.log(cookies.accessToken)
-			}
 			{
 				cookies.accessToken && (dimension.width <= 480) &&
 				<LoginHeaderSP/>

--- a/src/containers/Chats.jsx
+++ b/src/containers/Chats.jsx
@@ -78,6 +78,25 @@ export const Chats = () => {
 		fontFamily: 'HiraKakuProN-W6',
 	});
 
+	const NoChats = styled('div')(({ theme }) =>({
+		fontSize: 18,
+		paddingRight:'22%',
+		paddingLeft:'22%',
+		paddingTop: 25,
+		paddingBottom: 25,
+		"@media screen and (max-width:480px)":{
+			fontSize: 15,
+		},
+		fontFamily: 'HiraKakuProN-W6',
+		color: theme.palette.text.primary,
+	}));
+
+	const CircularWrapper = styled('div')({
+		paddingTop: 60,
+		display: 'flex',
+		justifyContent: 'center',
+	});
+
 	const initialState = {
 		isChatsEmpty: false,
 		hasChats: false,
@@ -155,34 +174,47 @@ export const Chats = () => {
 		<Fragment>
 			<ThemeProvider theme={Theme}>
 			<Container maxWidth='lg'>
-				<ChatsTitle>
-				メッセージ
-				</ChatsTitle>
 				{
-					fetchState.fetching &&
-					<CircularProgress/>
-				}
-				<ChatsWrapper>
-				{
-					state.isChatsEmpty && fetchState.fetched &&
-					<div>
-					飲み会依頼はまだ届いていません！<br/>
-					届くまでもう少々お待ちください。
-					</div>
+					cookies.accessToken === undefined &&
+						<Fade in={true}><Alert severity="error">ログインしてください！</Alert></Fade>
 				}
 				{
-					state.hasChats && fetchState.fetched &&
-					<FixedSizeList
-					height={480}
-					width={'100%'}
-					itemSize={88}
-					itemCount={chatsInfo.length}
-					overscanCount={5}
-					>
-					{renderRow}
-					</FixedSizeList>
+					cookies.accessToken &&
+					<>
+					<ChatsTitle>
+					メッセージ
+					</ChatsTitle>
+					{
+						fetchState.fetching &&
+						<CircularWrapper>
+							<CircularProgress size={50}/>
+						</CircularWrapper>
+					}
+					{
+						state.isChatsEmpty && fetchState.fetched &&
+					<ChatsWrapper>
+						<NoChats>
+						メッセージはまだ届いていません！<br/>
+						届くまでもう少々お待ちください。
+						</NoChats>
+					</ChatsWrapper>
+					}
+					{
+						state.hasChats && fetchState.fetched &&
+					<ChatsWrapper>
+						<FixedSizeList
+						height={480}
+						width={'100%'}
+						itemSize={88}
+						itemCount={chatsInfo.length}
+						overscanCount={5}
+						>
+						{renderRow}
+						</FixedSizeList>
+					</ChatsWrapper>
+					}
+					</>
 				}
-				</ChatsWrapper>
 			</Container>
 			</ThemeProvider>
 		</Fragment>

--- a/src/containers/LogIn.jsx
+++ b/src/containers/LogIn.jsx
@@ -10,6 +10,7 @@ import Alert from '@mui/material/Alert';
 import { HTTP_STATUS_CODE } from '../constants'
 import{
 	useHistory,
+	useLocation,
 } from "react-router-dom";
 import { useCookies } from 'react-cookie';
 import Fade from '@mui/material/Fade';
@@ -79,6 +80,7 @@ export const LogIn = () => {
 	const[state, setState] = useState(initialState);
 
 	const history = useHistory();
+	const location = useLocation();
 
 	const cookiesArray = useCookies(["accessToken"]);
 	const cookies = cookiesArray[0]
@@ -93,8 +95,12 @@ export const LogIn = () => {
 		.then((resData)=>{
 			let cookieDate = new Date()
 			cookieDate.setDate(cookieDate.getDate()+7);
-			setCookie("accessToken", resData.headers['accesstoken'], {expires: cookieDate, sameSite: 'none', secure: true})
-			history.push("/mypage",{loginNotice: true});
+			setCookie("accessToken", resData.headers['accesstoken'], {expires: cookieDate, sameSite: 'none', secure: true, path: '/'})
+			if(location.state === undefined){
+				history.push("/mypage",{loginNotice: true});
+			}else{
+				history.push(location.state.redirectUrl);
+			}
 		}).catch((e) => {
 			if(e.response.status === HTTP_STATUS_CODE.UNAUTHORIZED){
 				setState({
@@ -113,7 +119,7 @@ export const LogIn = () => {
 			<Container maxWidth='lg'>
 				<MessageWrapper>
 				{
-					cookies['accessToken'] !== undefined &&
+					cookies.accessToken !== undefined &&
 						<Fade in={true}><Alert severity="warning">既にログインしています。</Alert></Fade>
 				}
 				{

--- a/src/containers/LoginHeader.jsx
+++ b/src/containers/LoginHeader.jsx
@@ -56,7 +56,8 @@ export const LoginHeader = () => {
 		if(window.confirm('ログアウトしますか？')){
 		LogOut(cookies["accessToken"])
 		.then(() => {
-			removeCookie('accessToken')
+			console.log(cookies)
+			removeCookie('accessToken', {path: '/'})
 			history.push("/",{logoutNotice: true})
 		}).catch(
 		)}

--- a/src/containers/LoginHeaderSP.jsx
+++ b/src/containers/LoginHeaderSP.jsx
@@ -52,7 +52,6 @@ export const LoginHeaderSP = () => {
 		if(window.confirm('ログアウトしますか？')){
 		LogOut(cookies["accessToken"])
 		.then(() => {
-			console.log(cookies)
 			removeCookie('accessToken', {path: '/'})
 			history.push("/",{logoutNotice: true})
 		}).catch(

--- a/src/containers/LoginHeaderSP.jsx
+++ b/src/containers/LoginHeaderSP.jsx
@@ -52,7 +52,8 @@ export const LoginHeaderSP = () => {
 		if(window.confirm('ログアウトしますか？')){
 		LogOut(cookies["accessToken"])
 		.then(() => {
-			removeCookie('accessToken')
+			console.log(cookies)
+			removeCookie('accessToken', {path: '/'})
 			history.push("/",{logoutNotice: true})
 		}).catch(
 		)}

--- a/src/containers/RegisterRecommendDialog.jsx
+++ b/src/containers/RegisterRecommendDialog.jsx
@@ -10,11 +10,11 @@ import { TIME, NUMBER_OF_PEOPLE, BUDGET } from '../constants'
 import { setAtmosphere } from '../functions/setAtmosphere';
 import{
 	useHistory,
+	useLocation
 } from "react-router-dom";
 
-
 export const RegisterRecommendDialog = ({
-	receiverName,
+	receivername,
 	open,
 	onClose,
 }) => {
@@ -123,19 +123,19 @@ export const RegisterRecommendDialog = ({
 		marginTop: 30,
 	});
 
+	const location = useLocation();
 	const history = useHistory();
 
 	return (
 		<ThemeProvider theme={Theme}>
 		<Dialog
 		open = {open}
-		receiverName = {receiverName}
 		onClose = {onClose}		
 		>
 		<DialogContent>
 			<DialogWrapper>
 			ログインした後に依頼を送信すると<br/>
-			後で<ReceiverName>やまーだ</ReceiverName>さんとチャットすることができます！
+			あとで<ReceiverName>{receivername}</ReceiverName>さんとチャットすることができます！
 			</DialogWrapper>
 			<ButtonWrapperTop>
 			<EmphasizedButton
@@ -143,7 +143,7 @@ export const RegisterRecommendDialog = ({
 			variant='outlined'
 			color='inherit'
 			onClick={()=>{
-				history.push("/", {logoutNotice: false});
+				history.push("/signin", {redirectUrl: location.pathname });
 			}}
 			>
 			新規登録
@@ -153,7 +153,7 @@ export const RegisterRecommendDialog = ({
 			variant='outlined'
 			color='inherit'
 			onClick={()=>{
-				history.push("/", {logoutNotice: false});
+				history.push("/login", {redirectUrl: location.pathname});
 			}}
 			>
 			ログイン
@@ -166,9 +166,9 @@ export const RegisterRecommendDialog = ({
 			<NormalButton
 			variant='outlined'
 			color='inherit'
-			onClick={()=>{
-				history.push("/", {logoutNotice: false});
-			}}
+			onClick={
+				onClose
+			}
 			>
 			チャット機能なしで飲み会依頼を送る！
 			</NormalButton>

--- a/src/containers/RequestForm.jsx
+++ b/src/containers/RequestForm.jsx
@@ -212,7 +212,7 @@ export const RequestForm = ({
 				{
 					!cookies.accessToken &&
 					<RegisterRecommendDialog
-					receiverName = {request.receiverName}
+					receivername = {request.receiverName}
 					open={state.isOpenRecommendDialog}
 					onClose={() => setState({
 						...state,

--- a/src/containers/SignIn.jsx
+++ b/src/containers/SignIn.jsx
@@ -13,6 +13,7 @@ import { HTTP_STATUS_CODE } from '../constants'
 import Fade from '@mui/material/Fade';
 import{
 	useHistory,
+	useLocation,
 } from "react-router-dom";
 import { useCookies } from 'react-cookie';
 import {usePageTracking} from '../functions/useTracking';
@@ -102,6 +103,7 @@ export const SignIn = () => {
 
 	const[state, setState] = useState(initialState);
 	const history = useHistory()
+	const location = useLocation()
 	const cookiesArray = useCookies(["accessToken"]);
 	const setCookie = cookiesArray[1]
 
@@ -120,8 +122,12 @@ export const SignIn = () => {
 			})
 			let cookieDate = new Date()
 			cookieDate.setDate(cookieDate.getDate()+7);
-			setCookie("accessToken", resData.headers['accesstoken'], {expires: cookieDate, sameSite: 'none', secure: true})
-			history.push("/mypage",{loginNotice: true});
+			setCookie("accessToken", resData.headers['accesstoken'], {expires: cookieDate, sameSite: 'none', secure: true, path: '/'})
+			if(location.state === undefined){
+				history.push("/mypage",{loginNotice: true});
+			}else{
+				history.push(location.state.redirectUrl);
+			}
 			}
 		).catch((e) => {
 			if(e.response.status === HTTP_STATUS_CODE.BAD_REQUEST){

--- a/src/providers/UserInfoProvider.jsx
+++ b/src/providers/UserInfoProvider.jsx
@@ -6,7 +6,7 @@ export const UserInfoProvider = props => {
 	const { children } = props;
 
 	const initialState = {
-		id: 0,
+		id: "",
 		name: "",
 		random_id: "",
 	}


### PR DESCRIPTION
## 概要
未ログインユーザーが飲み会依頼送信ページに遷移したときにモーダルを表示する。
モーダルから新規登録またはログインしたあと、飲み会依頼送信ページにリダイレクトする。

## なぜこの機能を追加するのか
未ログインユーザーにログインを促すため。
未ログインユーザーにログインした際のメリット（送信相手とチャットできること）を伝え、ログインを促す。

## やったこと
- RegisterRecommendDialogコンポーネントを作成
- SignInコンポーネントを修正し、飲み会依頼送信ページにリダイレクトできるようにした。
- LogInコンポーネントを修正し、飲み会依頼送信ページにリダイレクトできるようにした。
- setCookieメソッド、removeCookieメソッドにパスを指定するよう修正。
