### PR TITLE
飲み会依頼機能修正

### DIFF
--- a/src/containers/Chat.jsx
+++ b/src/containers/Chat.jsx
@@ -153,7 +153,7 @@ export const Chat = (props) => {
 	},[receivedMessage])
 
 	useLayoutEffect(() => {
-		if(userInfo.id === ''){
+		if((cookies.accessToken) && (userInfo.id === '')){
 			getCurrentUser(cookies.accessToken)
 			.then((data) => {
 				setUserInfo({id: data['data'].id, name: data['data']['attributes']['name'], random_id: data['data']['attributes']['random_id'] })

--- a/src/containers/Chats.jsx
+++ b/src/containers/Chats.jsx
@@ -114,6 +114,7 @@ export const Chats = () => {
 	function renderRow(props) {
 		const { index, style } = props;
 		const chat_message_length = chatsInfo[String(index)].chat_message.length
+		console.log(chatsInfo[String(index)])
 		const send_time = chatsInfo[String(index)].chat_message[String(chat_message_length - 1)].created_at.substr(0, 10).split('-').join('/')
 
 		return (

--- a/src/containers/Chats.jsx
+++ b/src/containers/Chats.jsx
@@ -114,7 +114,6 @@ export const Chats = () => {
 	function renderRow(props) {
 		const { index, style } = props;
 		const chat_message_length = chatsInfo[String(index)].chat_message.length
-		console.log(chatsInfo[String(index)])
 		const send_time = chatsInfo[String(index)].chat_message[String(chat_message_length - 1)].created_at.substr(0, 10).split('-').join('/')
 
 		return (
@@ -129,14 +128,14 @@ export const Chats = () => {
 					<Grid container>
 						<Grid item xs={10}>
 							<ListItemText
-							  primary={chatsInfo[String(index)].opponent['0'].name}
+							  primary={chatsInfo[String(index)].opponent.name}
 							  secondary={
 								<React.Fragment>
 								{chatsInfo[String(index)].chat_message[String(chat_message_length - 1)].message.substr(0, 5) + '...'}
 								</React.Fragment>
 							  }
 						  	  onClick={()=>{
-								  history.push('/chat', {opponentName: chatsInfo[String(index)].opponent['0'].name, 
+								  history.push('/chat', {opponentName: chatsInfo[String(index)].opponent.name, 
 									  messageInfo: chatsInfo[String(index)].chat_message,
 									  roomId: chatsInfo[String(index)].id,
 								 })

--- a/src/containers/LoginFooterSP.jsx
+++ b/src/containers/LoginFooterSP.jsx
@@ -22,8 +22,9 @@ const Theme = createTheme({
 const FooterWrapper = styled('div')(({ theme }) => ({
 	height: 60,
 	position: 'sticky',
+	Top:'100%',
 	bottom: 0,
-	zIndex: 10,
+	zIndex: 999,
 	width: '100%',
 	display: 'flex',
 	justifyContent: 'center',

--- a/src/containers/Message.jsx
+++ b/src/containers/Message.jsx
@@ -86,9 +86,6 @@ export const Message = (props) => {
 	
 	return(
 		<>
-		{
-			console.log(props.message)
-		}
 		<MessageListItem>
 			<Value>{props.message}</Value>
 		</MessageListItem>

--- a/src/containers/Message.jsx
+++ b/src/containers/Message.jsx
@@ -78,6 +78,7 @@ export const Message = (props) => {
 		maxWidth: '80%',
 		width: 'auto',
 		overflowWrap: 'break-word',
+		whiteSpace: 'pre-wrap',
 	});
 	
 	const classes = props.isMe ? "p-chat__reverse" : "p-chat__row";
@@ -85,6 +86,9 @@ export const Message = (props) => {
 	
 	return(
 		<>
+		{
+			console.log(props.message)
+		}
 		<MessageListItem>
 			<Value>{props.message}</Value>
 		</MessageListItem>

--- a/src/containers/OpponentMessage.jsx
+++ b/src/containers/OpponentMessage.jsx
@@ -78,6 +78,7 @@ export const OpponentMessage = (props) => {
 		maxWidth: '80%',
 		width: 'auto',
 		overflowWrap: 'break-word',
+		whiteSpace: 'pre-wrap',
 	});
 
 	

--- a/src/containers/RequestDialog.jsx
+++ b/src/containers/RequestDialog.jsx
@@ -8,6 +8,7 @@ import {styled, ThemeProvider, createTheme} from '@mui/material/styles';
 import Cheers from '../images/Beer Celebration-rafiki.png';
 import { TIME, NUMBER_OF_PEOPLE, BUDGET } from '../constants'
 import { setAtmosphere } from '../functions/setAtmosphere';
+import { useCookies } from 'react-cookie';
 import{
 	useHistory,
 } from "react-router-dom";
@@ -92,6 +93,8 @@ export const RequestDialog = ({
 	});
 
 	const history = useHistory();
+	const cookiesArray = useCookies(["accessToken"]);
+	const cookies = cookiesArray[0]
 
 	return (
 		<ThemeProvider theme={Theme}>
@@ -152,16 +155,32 @@ export const RequestDialog = ({
 				送信完了!
 				</TitleWrapper>
 				<ButtonWrapper>
-				<SubmitButton
-				sx={{ bgcolor: 'main.primary' }}
-				variant='outlined'
-				color='inherit'
-				onClick={()=>{
-					history.push("/", {logoutNotice: false});
-				}}
-				>
-				トップページへ
-				</SubmitButton>
+				{
+					cookies.accessToken &&
+					<SubmitButton
+					sx={{ bgcolor: 'main.primary' }}
+					variant='outlined'
+					color='inherit'
+					onClick={()=>{
+						history.push("/mypage", {loginNotice: false});
+					}}
+					>
+					マイページへ
+					</SubmitButton>
+				}
+				{
+					!cookies.accessToken &&
+					<SubmitButton
+					sx={{ bgcolor: 'main.primary' }}
+					variant='outlined'
+					color='inherit'
+					onClick={()=>{
+						history.push("/", {logoutNotice: false});
+					}}
+					>
+					トップページへ
+					</SubmitButton>
+				}
 				</ButtonWrapper>
 			</DialogContent>
 		}


### PR DESCRIPTION
## 概要
ログインユーザーと未ログインユーザーで飲み会依頼送信時の動きを変えるようにした。

## なぜこの機能を追加するのか
ログインユーザーは送信相手とチャットすることができる。
この機能を追加するにあたり、飲み会依頼送信時のフローをログインユーザーと未ログインユーザーで変えるようにした。

## やったこと
- RequestFormコンポーネント修正(依頼送信時にユーザーのログイン有無を送信するようにした)
- RequestFormDialogコンポーネント修正(依頼送信後モーダルのレイアウトをログインユーザーと未ログインユーザーで変えた)
- 不要なconsole.logを削除した。
